### PR TITLE
Fix content URI for devices before Android 10

### DIFF
--- a/android/src/main/java/com/zhgwu/shared_preferences_content_provider/Constants.java
+++ b/android/src/main/java/com/zhgwu/shared_preferences_content_provider/Constants.java
@@ -1,7 +1,6 @@
 package com.zhgwu.shared_preferences_content_provider;
 
 public class Constants {
-    public static final String URI = "com.zhgwu.shared_preferences_content_provider.SharedPreferencesContentProvider";
     public static final String INIT_METHOD = "init";
     public static final String GET_METHOD = "get";
     public static final String PUT_STRING_METHOD = "putString";

--- a/android/src/main/java/com/zhgwu/shared_preferences_content_provider/SharedPreferencesContentProviderPlugin.java
+++ b/android/src/main/java/com/zhgwu/shared_preferences_content_provider/SharedPreferencesContentProviderPlugin.java
@@ -167,7 +167,7 @@ public class SharedPreferencesContentProviderPlugin implements FlutterPlugin, Me
     }
 
     private Bundle call(String method, String arg, Bundle extras) {
-        Uri uri = Uri.parse(URI);
+        Uri uri = Uri.parse("content://" + authority);
         ContentResolver cr = context.getContentResolver();
         Bundle bundle;
 


### PR DESCRIPTION
This PR fixes #5 by changing the used URI to the form `content://$authority`